### PR TITLE
Change to Alpine 3.4

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.4
 
 RUN apk add --update \
 		bash \


### PR DESCRIPTION
Currently as it is set as alpine:edge and there is a python issue in alpine edge, it is failing.
It seems kind of dangerous any way to rely on an edge version